### PR TITLE
Allow disabling plugins with $BEETS_DISABLED_PLUGINS.

### DIFF
--- a/beets/plugins.py
+++ b/beets/plugins.py
@@ -18,6 +18,7 @@
 from __future__ import division, absolute_import, print_function
 
 import traceback
+import os
 import re
 import inspect
 import abc
@@ -268,7 +269,12 @@ def load_plugins(names=()):
     package in sys.path; the module indicated should contain the
     BeetsPlugin subclasses desired.
     """
+    disabled_plugins = os.environ.get('BEETS_DISABLED_PLUGINS', '').split(',')
     for name in names:
+        if name in disabled_plugins:
+            log.debug(u'Skipping disabled plugin {0}', name)
+            continue
+
         modname = '{0}.{1}'.format(PLUGIN_NAMESPACE, name)
         try:
             try:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -80,6 +80,8 @@ New features:
 * :doc:`/plugins/beatport`: Fix assignment of `genre` and rename `musical_key`
   to `initial_key`.
   :bug:`3387`
+* Plugins can be disabled by setting the `BEETS_DISABLED_PLUGINS`
+  environment variable to a comma seperated list of plugins.
 
 Fixes:
 


### PR DESCRIPTION
## Description

Fixes #X.  <!-- Insert issue number here if applicable. -->

(...)

## To Do

- [ ] Documentation. (If you've add a new command-line flag, for example, find the appropriate page under `docs/` to describe it.)
- [ ] Changelog. (Add an entry to `docs/changelog.rst` near the top of the document.)
- [ ] Tests. (Encouraged but not strictly required.)
